### PR TITLE
Standardize dependabot.yml and pin MiraGeoscience/CI-tools refs to @v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,30 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 4
+    ignore:
+      - dependency-name: "MiraGeoscience/CI-tools/.github/actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "MiraGeoscience/CI-tools/.github/workflows/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      github-actions:
+        patterns:
+          - actions/*
+      mirageo-ci-tools:
+        patterns:
+          - MiraGeoscience/CI-tools/.github/actions/*
+          - MiraGeoscience/CI-tools/.github/workflows/*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 4
-    ignore:
-      - dependency-name: "MiraGeoscience/CI-tools/.github/actions/*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-      - dependency-name: "MiraGeoscience/CI-tools/.github/workflows/*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   call-workflow-create-jira-issue:
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3
-    secrets: inherit
+    permissions:
+      issues: write
+    secrets:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL_WRITE }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN_WRITE }}
     with:
       project_key: 'GEOPY'

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-create-jira-issue:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v1.0.0
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3
     secrets: inherit
     with:
       project_key: 'GEOPY'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -24,14 +24,14 @@ concurrency:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@v3
     with:
       package-manager: 'poetry'
       app-name: 'mirageoscience'
       python-version: '3.10'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@v3
     with:
       package-manager: 'poetry'
       python-versions: '["3.10", "3.11", "3.12"]'


### PR DESCRIPTION
DEVOPS-1128: CI-tools config updates, applied wherever relevant to this repo:
- Standardize dependabot.yml's github-actions entry (weekly schedule, cooldown, mirageo-ci-tools group) to match the rest of the org.
- Pin any MiraGeoscience/CI-tools action/workflow ref that floated on @main/@v2/@v1.0.0 to @v3.

(Earlier revisions of this PR also added a dependabot ignore rule for CI-tools minor/patch updates - that's been dropped, we decided not to proceed with it.)

This PR was run by a PowerShell script with the help of Copilot.